### PR TITLE
Clean before install and minimize after

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ cache:
   - $HOME/.jdk
 sudo: false
 env:
-  global:
-  - JDKW_VERSION=8u65
-  - JDKW_BUILD=b17
+  - JDKW_VERSION=8u74 JDKW_BUILD=b02
 install: true
 script:
 - ./jdk-wrapper.sh javac -version
-- if [ "$(./jdk-wrapper.sh javac -version 2>&1 | tail -n 1)" != "javac 1.8.0_65" ]; then exit 1; fi;
+- if [ "$(./jdk-wrapper.sh javac -version 2>&1 | tail -n 1)" != "javac 1.8.0_74" ]; then exit 1; fi;

--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ env:
   - JDKW_BUILD=b17
 ```
 
-To build against multiple versions of the Oracle JDK please refer to the [Travis documentation](https://docs.travis-ci.com/) for how to configure matrix builds.
+To create a matrix build against multiple versions of the Oracle JDK simply specify the environment variables like this:
+
+```yml
+env:
+  - JDKW_VERSION=7u79 JDKW_BUILD=b15
+  - JDKW_VERSION=8u74 JDKW_BUILD=b02
+```
 
 Finally, invoke your build command using the jdk-wrapper script. The following assumes you have downloaded and included jdk-wrapper.sh in your project.
 

--- a/jdk-wrapper.sh
+++ b/jdk-wrapper.sh
@@ -138,6 +138,9 @@ fi
 jdkid="${JDKW_VERSION}_${JDKW_BUILD}_${JDKW_PLATFORM}"
 if [ ! -f "${JDKW_TARGET}/${jdkid}/environment" ]; then
   log_out "Desired JDK version ${jdkid} not found"
+  if [ -d "${JDKW_TARGET}/${jdkid}" ]; then
+      safe_command "rm -rf \"${JDKW_TARGET}/${jdkid}\""
+  fi
 
   # Create target directory
   safe_command "mkdir -p \"${JDKW_TARGET}/${jdkid}\""
@@ -167,6 +170,7 @@ if [ ! -f "${JDKW_TARGET}/${jdkid}/environment" ]; then
   if [ "${JDKW_EXTENSION}" == "tar.gz" ]; then
     safe_command "tar -xzf \"${archive}\""
     package=`ls | grep "jdk[^-].*" | head -n 1`
+    safe_command "rm -f \"${archive}\""
     echo "export JAVA_HOME=\"${JDKW_TARGET}/${jdkid}/${package}\"" > "${JDKW_TARGET}/${jdkid}/environment"
   elif [ "${JDKW_EXTENSION}" == "dmg" ]; then
     result=`hdiutil attach "${archive}" | grep -P "/Volumes/.*"`
@@ -177,6 +181,9 @@ if [ ! -f "${JDKW_TARGET}/${jdkid}/environment" ]; then
     safe_command "hdiutil detach \"${mount}\" &> /dev/null"
     jdk=`ls | grep "jdk.*\.pkg" | head -n 1`
     safe_command "cpio -i < \"./${jdk}/Payload\" &> /dev/null"
+    safe_command "rm -f \"${archive}\""
+    safe_command "rm -rf \"${jdk}\""
+    safe_command "rm -rf \"javaappletplugin.pkg\""
     echo "export JAVA_HOME=\"${JDKW_TARGET}/${jdkid}/Contents/Home\"" > "${JDKW_TARGET}/${jdkid}/environment"
   else
     log_err "Unsupported extension ${JDKW_EXTENSION}"


### PR DESCRIPTION
This addresses issue #7 cleaning the installation directory if it exists but does not have an environment file to source prior to install and issue #5 to delete extraneous files/directories left over from the installation (e.g. the downloaded tar.gz).
