### PR TITLE
update usage comments to show valid example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then execute jdk-wrapper.sh script without setting the environment variables.
 
 The third option is to pass arguments to jdk-wrapper.sh which define the configuration. Any argument that begins with "JDKW_" will be considered a configuration parameter, everything from the first non-configuration parameter onward is considered part of the command.
 
-    > jdk-wrapper.sh JDKW_VERSION=8u121 JDKW_BUILD=13 JDKW_TOKEN=e9e7ea248e2c4826b92b3f075a80e441 <CMD>
+    > jdk-wrapper.sh JDKW_VERSION=8u121 JDKW_BUILD=b13 JDKW_TOKEN=e9e7ea248e2c4826b92b3f075a80e441 <CMD>
 
 Finally, any combination of these three forms of configuration is permissible. Any environment variables override the values in the .jdkw file and any values specified on the command line override both the environment and the .jdkw file.
 

--- a/jdk-wrapper.sh
+++ b/jdk-wrapper.sh
@@ -26,14 +26,14 @@
 # with a call to the jdk_wrapper.sh script.
 #
 # e.g.
-# > JDKW_VERSION=8u65 JDKW_BUILD=13 jdk-wrapper.sh <CMD>
+# > JDKW_VERSION=8u65 JDKW_BUILD=b13 jdk-wrapper.sh <CMD>
 #
 # Alternatively, create a file called .jdkw in the working directory with the
 # configuration properties.
 #
 # e.g.
 # JDKW_VERSION=8u65
-# JDKW_BUILD=13
+# JDKW_BUILD=b13
 #
 # Then wrap your command:
 #
@@ -46,7 +46,7 @@
 # onward is considered part of the command.
 #
 # e.g.
-# > jdk-wrapper.sh JDKW_VERSION=8u65 JDKW_BUILD=13 <CMD>
+# > jdk-wrapper.sh JDKW_VERSION=8u65 JDKW_BUILD=b13 <CMD>
 #
 # Finally, any combination of these three forms of configuration is permissible.
 # Any environment variables override the values in the .jdkw file and any values


### PR DESCRIPTION
updating examples to include the 'b' prefix for `JDKW_BUILD` value since it's not automatically added by the script